### PR TITLE
Add HEALTHCHECK configuration

### DIFF
--- a/build/Dockerfile
+++ b/build/Dockerfile
@@ -67,7 +67,7 @@ RUN set -x \
 COPY /docker-entrypoint.sh /
 
 # Set up healthcheck.
-HEALTHCHECK --interval=15m --timeout=30s CMD $DSTA_HOME/version --check
+HEALTHCHECK --interval=5m --start-period=15m --timeout=30s --retries=3 CMD $DSTA_HOME/version --check
 
 # Expose default server port.
 EXPOSE $SERVER_PORT/udp

--- a/build/Dockerfile
+++ b/build/Dockerfile
@@ -67,7 +67,7 @@ RUN set -x \
 COPY /docker-entrypoint.sh /
 
 # Set up healthcheck.
-HEALTHCHECK --interval=5m --start-period=15m --timeout=30s --retries=3 CMD $DSTA_HOME/version --check
+HEALTHCHECK --interval=5m --timeout=30s --retries=3 CMD $DSTA_HOME/version --check
 
 # Expose default server port.
 EXPOSE $SERVER_PORT/udp

--- a/build/Dockerfile
+++ b/build/Dockerfile
@@ -66,6 +66,9 @@ RUN set -x \
 # Copy entrypoint script.
 COPY /docker-entrypoint.sh /
 
+# Set up healthcheck.
+HEALTHCHECK --interval=15m --timeout=30s CMD $DSTA_HOME/version --check
+
 # Expose default server port.
 EXPOSE $SERVER_PORT/udp
 

--- a/build/Dockerfile
+++ b/build/Dockerfile
@@ -67,7 +67,7 @@ RUN set -x \
 COPY /docker-entrypoint.sh /
 
 # Set up healthcheck.
-HEALTHCHECK --interval=5m --start-period=15m --timeout=30s --retries=3 CMD $DSTA_HOME/version --check
+HEALTHCHECK --interval=5m --start-period=15m --timeout=30s --retries=3 CMD dst-server version --check
 
 # Expose default server port.
 EXPOSE $SERVER_PORT/udp

--- a/build/Dockerfile
+++ b/build/Dockerfile
@@ -67,7 +67,7 @@ RUN set -x \
 COPY /docker-entrypoint.sh /
 
 # Set up healthcheck.
-HEALTHCHECK --interval=5m --timeout=30s --retries=3 CMD $DSTA_HOME/version --check
+HEALTHCHECK --interval=5m --start-period=15m --timeout=30s --retries=3 CMD $DSTA_HOME/version --check
 
 # Expose default server port.
 EXPOSE $SERVER_PORT/udp


### PR DESCRIPTION
This adds a `HEALTHCHECK` configuration to the Dockerfile. A container is healthy if it runs the latest DST version.

Tests fail currently for console-related tests. Not sure why tho.