### PR TITLE
Fix WORLD_PRESET usage with the new leveldataoverride configuration

### DIFF
--- a/build/static/boot/world.sh
+++ b/build/static/boot/world.sh
@@ -11,12 +11,21 @@ if [ -n "$LEVELDATA_OVERRIDES" ]; then
 elif [ -n "$WORLD_PRESET" ]; then
 	source "`dirname "$0"`/functions.sh"
 
-	validate_option "WORLD_PRESET" SURVIVAL_TOGETHER SURVIVAL_TOGETHER_CLASSIC SURVIVAL_DEFAULT_PLUS COMPLETE_DARKNESS DST_CAVE
+	validate_option "WORLD_PRESET" SURVIVAL_TOGETHER SURVIVAL_TOGETHER_CLASSIC SURVIVAL_DEFAULT_PLUS COMPLETE_DARKNESS DST_CAVE DST_CAVE_PLUS
+
+	if ["$WORLD_PRESET" == "DST_CAVE"] || ["$WORLD_PRESET" == "DST_CAVE_PLUS"]; then
+		location="cave"
+	else
+		location="forest"
+	fi
 
 	cat <<- EOF > $file_leveldata_override
 return {
   id = "$WORLD_PRESET",
-  version = 3,
+  location = "$location",
+  name="",
+  desc="",
+  overrides={},
 }
 EOF
 fi

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -226,6 +226,7 @@ Defines some pre-configured world settings for the server.
 - SURVIVAL_DEFAULT_PLUS
 - COMPLETE_DARKNESS
 - DST_CAVE
+- DST_CAVE_PLUS
 
 **LEVELDATA_OVERRIDES**  
 Sets the overrides-configuration for level-data. Basically it's just the content for the

--- a/test/boot-world/run.sh
+++ b/test/boot-world/run.sh
@@ -16,7 +16,10 @@ echo "foo" > $file1
 cat <<- EOF > $file2
 return {
   id = "bar",
-  version = 3,
+  location = "forest",
+  name="",
+  desc="",
+  overrides={},
 }
 EOF
 


### PR DESCRIPTION
Adds the new `DST_CAVE_PLUS` preset and fixes generation of the new `leveldataoverride.lua` file.