### PR TITLE
Include functions.sh before using containsElement

### DIFF
--- a/build/static/boot/mods.sh
+++ b/build/static/boot/mods.sh
@@ -1,5 +1,7 @@
 #!/usr/bin/env bash
 
+source "$(dirname "$0")/functions.sh"
+
 file_mods_setup="$DST_HOME/mods/dedicated_server_mods_setup.lua"
 file_mods_settings="$DST_HOME/mods/modsettings.lua"
 file_mods_overrides="$CLUSTER_PATH/$SHARD_NAME/modoverrides.lua"


### PR DESCRIPTION
The `containsElement` bash function is being used, but it is nowhere to be found. This causes an error that is visible in the logs and basically prevents this script from working.