### PR TITLE
Removing defected mod from example

### DIFF
--- a/docs/examples/mods/docker-compose.yml
+++ b/docs/examples/mods/docker-compose.yml
@@ -4,7 +4,7 @@ services:
     build:
       context: https://github.com/dst-academy/docker-dontstarvetogether.git#v0.8.0:build
       args:
-        MODS: 378160973,492173795,407705132
+        MODS: 378160973,407705132
     container_name: world
     hostname: world
     tty: true

--- a/docs/examples/mods/modoverrides.lua
+++ b/docs/examples/mods/modoverrides.lua
@@ -1,6 +1,5 @@
 return {
 	['workshop-378160973'] = { enabled = true },
-	['workshop-492173795'] = { enabled = true },
 	['workshop-407705132'] = { enabled = true,
 		configuration_options = {
 			title = 'Welcome!',


### PR DESCRIPTION
The mod #492173795 (aka Moderator Commands) is throwing the error
mentioned in issue #142. Since this is only an example, I'm removing the
mod.

Ticket: https://github.com/fairplay-zone/docker-dontstarvetogether/issues/142
Mod: https://steamcommunity.com/sharedfiles/filedetails/?id=492173795